### PR TITLE
fixed channel priority to work with strict priority

### DIFF
--- a/typhi_JINA.environment.yml
+++ b/typhi_JINA.environment.yml
@@ -5,3 +5,4 @@ channels:
 dependencies:
 - bindash=1.0
 - jellyfish=2.2.6
+- perl-getopt-long>=2.45

--- a/typhi_JINA.environment.yml
+++ b/typhi_JINA.environment.yml
@@ -1,7 +1,7 @@
 name: typhi_JINA
 channels:
-- conda-forge
 - bioconda
+- conda-forge
 dependencies:
 - bindash=1.0
 - jellyfish=2.2.6


### PR DESCRIPTION
strict priority, typically used by most `conda` users, will fail to install using this file. switching the channel order resolves this issue